### PR TITLE
Bugfix/#13550 remove login permissions to user

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -22,7 +22,7 @@ action :add do
     end
 
     execute 'create_user' do
-      command "/usr/sbin/useradd -r #{user} -s /sbin/nologin"
+      command "/usr/sbin/useradd #{user} -s /sbin/nologin"
       ignore_failure true
       not_if "getent passwd #{user}"
     end

--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -22,7 +22,7 @@ action :add do
     end
 
     execute 'create_user' do
-      command "/usr/sbin/useradd #{user}"
+      command "/usr/sbin/useradd -r #{user} -s /sbin/nologin"
       ignore_failure true
       not_if "getent passwd #{user}"
     end


### PR DESCRIPTION
Removing login permission to the user because we don't expect a user to do it to run a command.